### PR TITLE
test: add browser and webworker tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ stages:
 
 node_js:
   - '10'
+  - '12'
 
 os:
   - linux
@@ -24,6 +25,18 @@ jobs:
       script:
         - npx aegir dep-check
         - npm run lint
+
+    - stage: test
+      name: chrome
+      addons:
+        chrome: stable
+      script: npx aegir test -t browser -t webworker
+
+    - stage: test
+      name: firefox
+      addons:
+        firefox: latest
+      script: npx aegir test -t browser -t webworker -- --browsers FirefoxHeadless
 
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "url": "git+https://github.com/libp2p/js-peer-book.git"
   },
   "pre-push": [
-    "lint",
-    "test"
+    "lint"
   ],
   "files": [
     "src",

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ class PeerBook {
   }
 
   getAllArray () {
-    return Object.keys(this._peers).map((b58Str) => this._peers[b58Str])
+    return Object.values(this._peers)
   }
 
   getMultiaddrs (peer) {


### PR DESCRIPTION
* also adds node 12 to the build
* includes https://github.com/libp2p/js-peer-book/pull/41

I pulled #41 into this as it was being blocked by commitlint (which has since been resolved), this just avoids the need to rebase that branch.