### PR TITLE
chore: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-Peer Book JavaScript Implementation
-===================================
+⛔️ DEPRECATED: peer-books is now included in [libp2p](https://github.com/libp2p/js-libp2p/tree/master/src/peer-store) and renamed into `peer-store`.
+======
+
+# Peer Book JavaScript Implementation
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
 [![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)


### PR DESCRIPTION
In the context of [libp2p/js-libp2p#453](https://github.com/libp2p/js-libp2p/issues/453), as well as per discussion on [libp2p/js-peer-book#14#issuecomment-583956378](https://github.com/libp2p/js-peer-book/pull/14#issuecomment-583956378), a deprecation notice is added.

Needs:

- [x] npm deprecation notice

After merged, the repo must be archived (I do not have permissions to do it)